### PR TITLE
[Fix] TaskFileCompleted emits by flushFiles many times per file

### DIFF
--- a/lib/src/file/download_file_manager.dart
+++ b/lib/src/file/download_file_manager.dart
@@ -102,10 +102,10 @@ class DownloadFileManager with EventsEmittable<DownloadFileManagerEvent> {
         if (pieces == null) continue;
         if (flushed.add(file.filePath)) {
           await file.requestFlush();
-        }
-        if (file.completelyFlushed) {
-          //TODO: is this check enough ?
-          events.emit(DownloadManagerFileCompleted(file));
+          // Emit only once per file
+          if (file.completelyFlushed) {
+            events.emit(DownloadManagerFileCompleted(file));
+          }
         }
       }
     }


### PR DESCRIPTION
Issue Description:
`flushFiles` emits `TaskFileCompleted` as many times as the length of `pieceIndices.length`

What is the fix:
- [x] Emit `TaskFileCompleted` event only once per file
- [x] Add test